### PR TITLE
Убран лишний метод проверки существования родительской категории из сервиса

### DIFF
--- a/src/blueprints/transactions.py
+++ b/src/blueprints/transactions.py
@@ -49,7 +49,7 @@ class TransactionView(MethodView):
                         account_id
                     )
                 except CategoryDoesNotExistError:
-                    return '', 404
+                    return '', 400
                 except PermissionError:
                     return '', 403
             return jsonify(transaction), 200
@@ -85,7 +85,7 @@ class TransactionIDView(MethodView):
                     transaction_id
                 )
             except CategoryDoesNotExistError:
-                return '', 404
+                return '', 400
             except PermissionError:
                 return '', 403
         return jsonify(transaction), 200

--- a/src/services/categories.py
+++ b/src/services/categories.py
@@ -39,6 +39,7 @@ class CategoriesService:
                 INNER JOIN subtree ON categories.parent_id = subtree.id)
             SELECT id, name, parent_id
             FROM subtree
+            ORDER BY id
             """,
         )
         dict_category = [dict(elem) for elem in cur.fetchall()]
@@ -90,12 +91,6 @@ class CategoriesService:
         category = dict(self.get_category(category_id))
         if category['account_id'] != account_id:
             raise PermissionError
-    
-    def category_exists(self, category_id):
-        """Проверка существования категории (для родительской)"""
-        category = self.get_category(category_id)
-        if category is None:
-            raise CategoryDoesNotExistError
     
     def category_check(self, account_id, name_category):
         """Проверка категории на существование по имени"""

--- a/src/services/transactions.py
+++ b/src/services/transactions.py
@@ -13,7 +13,7 @@ class TransactionsService:
         """ Проверяет существование и является ли account_id
             владельцем категории под category_id """
         if category_id is not None:
-            CategoriesService(self.connection).category_exists(category_id)
+            CategoriesService(self.connection).parent_category_exists(category_id, account_id)
             CategoriesService(self.connection).is_category_owner(category_id, account_id)
     
     def create_transaction(self, transaction, account_id):


### PR DESCRIPTION
Исправлен вызов метода в транзакциях.
Исправлен код 404 на 400 в блюпринт/транзакции при указании несуществующей категории в теле запроса